### PR TITLE
Sync Project with generate-demo nox session and test CI/CD

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Git tag to build and release (e.g., v1.2.3). Must already exist."
+        description: 'Git tag to build and release (e.g., v1.2.3). Must already exist.'
         required: true
 
 jobs:
@@ -103,6 +103,7 @@ jobs:
           # Optional: TWINE_REPOSITORY if publishing to a custom production index
         run: uvx nox -s publish-package # Call the publish-package session (defaults to pypi.org)
 
+
   # Job 3: Create GitHub Release (Runs regardless of PyPI publish success, relies on build job for info/artifacts)
   create_github_release:
     name: Create GitHub Release
@@ -133,6 +134,7 @@ jobs:
           name: Release ${{ steps.get_tag.outputs.tag }}
           # The body of the release notes - access the output from the 'build_and_testpypi' job
           body: ${{ needs.build_and_testpypi.outputs.changelog_body }} # Access changelog body from dependent job output
+
 
           files: dist/* # Attach built sdist and wheel files as release assets
           # Optional: Mark as a draft release for manual review before publishing

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,14 +60,6 @@ repos:
       - id: prettier
         name: Prettier
 
-  - repo: https://github.com/doublify/pre-commit-rust
-    rev: master
-    hooks:
-      - id: fmt
-      - id: clippy
-        args: ["--all-features", "--", "--write"]
-      - id: cargo-check
-
   - repo: https://github.com/commitizen-tools/commitizen
     rev: v4.8.2
     hooks:
@@ -75,4 +67,4 @@ repos:
         name: Commitizen
       - id: commitizen-branch
         name: Commitizen Branch
-        stages: [commit-msg]
+        stages: [ commit-msg ]

--- a/noxfile.py
+++ b/noxfile.py
@@ -124,7 +124,7 @@ def tests_python(session: Session) -> None:
         "--cov-report=term",
         "--cov-report=xml",
         f"--junitxml={junitxml_file}",
-        "tests/",
+        "tests/"
     )
 
 


### PR DESCRIPTION
Ensuring everything is synced up directly to the project generation and not including any git commit hook changes that weren't meant to be included with the cruft updates previously.

Also testing out how commitizen goes about making a release since it appears at a glance to not follow git flow, but I'm curious to see what the github action alone does.